### PR TITLE
Use Agno for Gemini example and fix datetime timezone references

### DIFF
--- a/examples/agno-telemetry/README.md
+++ b/examples/agno-telemetry/README.md
@@ -1,0 +1,37 @@
+## Agno + BMasterAI Telemetry Example
+
+This example shows how the [Agno](https://github.com/agno-ai/agno) agent framework can
+call Google's Gemini models while recording rich BMasterAI telemetry and optionally
+emitting alerts through the `bmasterai_telemetry` extension.
+
+### Why it's exciting
+
+- **Native Agno agent** – uses the high level `Agent` interface to interact with Gemini.
+- **Full observability** – BMasterAI logging and monitoring capture agent lifecycle
+  events, token usage and latency metrics out of the box.
+- **Alerting hooks** – simple token budgets can trigger Slack or Teams alerts via
+  `bmasterai_telemetry`.
+- **Minimal setup** – a single script demonstrates how to combine the two libraries.
+
+### Requirements
+
+- Python 3.10+
+- Environment variable `GOOGLE_API_KEY` containing a valid Gemini API key.
+- (Optional) `BMASTERAI_ALERTS_SLACK_WEBHOOK` and/or `BMASTERAI_ALERTS_TEAMS_WEBHOOK`
+  for alert delivery.
+- Install dependencies:
+
+```bash
+pip install agno google-generativeai bmasterai
+```
+
+### Run
+
+```bash
+export GOOGLE_API_KEY=your-key
+python gemini_agno_example.py
+```
+Set `TOKEN_BUDGET` to enable alerting when the token usage exceeds the limit. The script
+prints the Gemini response and records structured telemetry in logs and metrics files,
+sending optional alerts when budgets are breached.
+

--- a/examples/agno-telemetry/gemini_agno_example.py
+++ b/examples/agno-telemetry/gemini_agno_example.py
@@ -1,0 +1,83 @@
+import os
+import time
+
+from agno.agent import Agent
+from agno.models.google import Gemini
+
+from bmasterai.logging import configure_logging, LogLevel, EventType
+from bmasterai.monitoring import get_monitor
+from bmasterai_telemetry.alerts.slack import build_slack_alert, send_slack_alert
+from bmasterai_telemetry.alerts.teams import send_teams_alert
+
+
+def main() -> None:
+    """Run a simple Gemini prompt using the Agno agent framework.
+
+    The example shows how to combine Agno with BMasterAI telemetry. It records
+    agent lifecycle events and basic LLM metrics for a single Gemini call.
+    An environment variable named ``GOOGLE_API_KEY`` must contain a valid
+    Gemini API key for the call to succeed.
+    """
+    # Set up BMasterAI logging and monitoring
+    logger = configure_logging(log_level=LogLevel.INFO, enable_console=True)
+    monitor = get_monitor()
+    monitor.start_monitoring()
+
+    agent_id = "agno-gemini-example"
+    monitor.track_agent_start(agent_id)
+
+    # Create an Agno agent that talks to Gemini
+    agent = Agent(
+        model=Gemini(id="gemini-1.5-flash", api_key=os.environ.get("GOOGLE_API_KEY")),
+        markdown=True,
+        description="A helpful agent demonstrating Agno + BMasterAI telemetry",
+    )
+
+    prompt = "Write a short haiku about observability for AI agents."
+
+    start_time = time.time()
+    response = agent.run(prompt)
+    duration_ms = (time.time() - start_time) * 1000
+
+    tokens_used = 0
+    raw = getattr(response, "raw_response", None)
+    if raw is not None:
+        usage = getattr(raw, "usage_metadata", None)
+        if usage and getattr(usage, "total_token_count", None) is not None:
+            tokens_used = usage.total_token_count
+
+    # Record metrics and log the LLM call
+    monitor.track_llm_call(agent_id, "gemini-1.5-flash", tokens_used, duration_ms)
+    logger.log_event(
+        agent_id=agent_id,
+        event_type=EventType.LLM_CALL,
+        message="Gemini response received",
+        metadata={"tokens_used": tokens_used},
+        duration_ms=duration_ms,
+    )
+
+    # Optional: send Slack/Teams alerts if token usage exceeds a simple budget
+    token_budget = int(os.getenv("TOKEN_BUDGET", "500"))
+    if tokens_used > token_budget:
+        alert_text = (
+            f"\U0001F6A8 Token budget breach for agent {agent_id}: "
+            f"{tokens_used} tokens used > {token_budget} limit"
+        )
+        dashboard_url = os.getenv(
+            "BMASTERAI_DASHBOARD_URL", "http://localhost:3000/d/agent-dashboard"
+        )
+        send_slack_alert(build_slack_alert(alert_text, dashboard_url))
+        send_teams_alert(agent_id, alert_text, dashboard_url)
+
+    print(response.content)
+
+    monitor.track_agent_stop(agent_id)
+    logger.log_event(
+        agent_id=agent_id,
+        event_type=EventType.AGENT_STOP,
+        message="Example complete",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/enhanced-github-mcp-streamlit/utils/bmasterai_logging.py
+++ b/examples/enhanced-github-mcp-streamlit/utils/bmasterai_logging.py
@@ -4,7 +4,7 @@ import json
 import logging
 import time
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Dict, Any, Optional
 from pathlib import Path
@@ -103,7 +103,7 @@ class StructuredLogger:
         """Log an event with structured metadata"""
         
         log_entry = {
-            "timestamp": datetime.now(datetime.UTC).isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "session_id": self.session_id,
             "agent_id": agent_id,
             "event_type": event_type.value,

--- a/examples/enhanced-github-mcp-streamlit/utils/bmasterai_monitoring.py
+++ b/examples/enhanced-github-mcp-streamlit/utils/bmasterai_monitoring.py
@@ -3,7 +3,7 @@
 import time
 import psutil
 import threading
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict, Any, List, Optional, Callable
 from dataclasses import dataclass, asdict
 import json
@@ -104,7 +104,7 @@ class MetricsCollector:
             network = psutil.net_io_counters()
             
             metrics = SystemMetrics(
-                timestamp=datetime.now(datetime.UTC).isoformat(),
+                timestamp=datetime.now(timezone.utc).isoformat(),
                 cpu_percent=cpu_percent,
                 memory_percent=memory.percent,
                 memory_used_mb=memory.used / (1024 * 1024),
@@ -125,11 +125,11 @@ class MetricsCollector:
     
     def track_agent_start(self, agent_id: str):
         """Track agent start event"""
-        self.agent_metrics[agent_id]["last_activity"] = datetime.now(datetime.UTC).isoformat()
+        self.agent_metrics[agent_id]["last_activity"] = datetime.now(timezone.utc).isoformat()
     
     def track_agent_stop(self, agent_id: str):
         """Track agent stop event"""
-        self.agent_metrics[agent_id]["last_activity"] = datetime.now(datetime.UTC).isoformat()
+        self.agent_metrics[agent_id]["last_activity"] = datetime.now(timezone.utc).isoformat()
     
     def track_task_duration(self, agent_id: str, task_name: str, duration_ms: float):
         """Track task execution duration"""
@@ -137,13 +137,13 @@ class MetricsCollector:
         metrics["tasks_completed"] += 1
         metrics["task_durations"].append(duration_ms)
         metrics["total_execution_time"] += duration_ms
-        metrics["last_activity"] = datetime.now(datetime.UTC).isoformat()
+        metrics["last_activity"] = datetime.now(timezone.utc).isoformat()
     
     def track_error(self, agent_id: str, error_type: str):
         """Track error occurrence"""
         metrics = self.agent_metrics[agent_id]
         metrics["tasks_failed"] += 1
-        metrics["last_activity"] = datetime.now(datetime.UTC).isoformat()
+        metrics["last_activity"] = datetime.now(timezone.utc).isoformat()
         
         # Record error metric
         self.record_custom_metric("agent_errors", 1, {"agent_id": agent_id, "error_type": error_type})
@@ -158,7 +158,7 @@ class MetricsCollector:
     def record_custom_metric(self, metric_name: str, value: float, tags: Dict[str, str]):
         """Record a custom metric"""
         metric_entry = {
-            "timestamp": datetime.now(datetime.UTC).isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "value": value,
             "tags": tags
         }
@@ -188,7 +188,7 @@ class MetricsCollector:
         if metric_name not in self.custom_metrics:
             return
         
-        cutoff_time = datetime.now(datetime.UTC) - timedelta(minutes=rule.duration_minutes)
+        cutoff_time = datetime.now(timezone.utc) - timedelta(minutes=rule.duration_minutes)
         recent_values = []
         
         for entry in self.custom_metrics[metric_name]:
@@ -220,7 +220,7 @@ class MetricsCollector:
                 "current_value": avg_value,
                 "condition": rule.condition,
                 "duration_minutes": rule.duration_minutes,
-                "timestamp": datetime.now(datetime.UTC).isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
                 "message": f"{metric_name} {rule.condition} {rule.threshold} for {rule.duration_minutes} minutes"
             }
             
@@ -248,7 +248,7 @@ class MetricsCollector:
             agent_id for agent_id, metrics in self.agent_metrics.items()
             if metrics["last_activity"] and 
             datetime.fromisoformat(metrics["last_activity"]) > 
-            datetime.now(datetime.UTC) - timedelta(minutes=10)
+            datetime.now(timezone.utc) - timedelta(minutes=10)
         ])
         
         # Calculate totals
@@ -303,7 +303,7 @@ class MetricsCollector:
     
     def get_metrics_history(self, metric_name: str, hours: int = 1) -> List[Dict[str, Any]]:
         """Get historical data for a metric"""
-        cutoff_time = datetime.now(datetime.UTC) - timedelta(hours=hours)
+        cutoff_time = datetime.now(timezone.utc) - timedelta(hours=hours)
         
         if metric_name == "system":
             return [

--- a/examples/mcp-github-streamlit/utils/bmasterai_logging.py
+++ b/examples/mcp-github-streamlit/utils/bmasterai_logging.py
@@ -4,7 +4,7 @@ import json
 import logging
 import time
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Dict, Any, Optional
 from pathlib import Path
@@ -103,7 +103,7 @@ class StructuredLogger:
         """Log an event with structured metadata"""
         
         log_entry = {
-            "timestamp": datetime.now(datetime.UTC).isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "session_id": self.session_id,
             "agent_id": agent_id,
             "event_type": event_type.value,

--- a/examples/mcp-github-streamlit/utils/bmasterai_monitoring.py
+++ b/examples/mcp-github-streamlit/utils/bmasterai_monitoring.py
@@ -3,7 +3,7 @@
 import time
 import psutil
 import threading
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict, Any, List, Optional, Callable
 from dataclasses import dataclass, asdict
 import json
@@ -104,7 +104,7 @@ class MetricsCollector:
             network = psutil.net_io_counters()
             
             metrics = SystemMetrics(
-                timestamp=datetime.now(datetime.UTC).isoformat(),
+                timestamp=datetime.now(timezone.utc).isoformat(),
                 cpu_percent=cpu_percent,
                 memory_percent=memory.percent,
                 memory_used_mb=memory.used / (1024 * 1024),
@@ -125,11 +125,11 @@ class MetricsCollector:
     
     def track_agent_start(self, agent_id: str):
         """Track agent start event"""
-        self.agent_metrics[agent_id]["last_activity"] = datetime.now(datetime.UTC).isoformat()
+        self.agent_metrics[agent_id]["last_activity"] = datetime.now(timezone.utc).isoformat()
     
     def track_agent_stop(self, agent_id: str):
         """Track agent stop event"""
-        self.agent_metrics[agent_id]["last_activity"] = datetime.now(datetime.UTC).isoformat()
+        self.agent_metrics[agent_id]["last_activity"] = datetime.now(timezone.utc).isoformat()
     
     def track_task_duration(self, agent_id: str, task_name: str, duration_ms: float):
         """Track task execution duration"""
@@ -137,13 +137,13 @@ class MetricsCollector:
         metrics["tasks_completed"] += 1
         metrics["task_durations"].append(duration_ms)
         metrics["total_execution_time"] += duration_ms
-        metrics["last_activity"] = datetime.now(datetime.UTC).isoformat()
+        metrics["last_activity"] = datetime.now(timezone.utc).isoformat()
     
     def track_error(self, agent_id: str, error_type: str):
         """Track error occurrence"""
         metrics = self.agent_metrics[agent_id]
         metrics["tasks_failed"] += 1
-        metrics["last_activity"] = datetime.now(datetime.UTC).isoformat()
+        metrics["last_activity"] = datetime.now(timezone.utc).isoformat()
         
         # Record error metric
         self.record_custom_metric("agent_errors", 1, {"agent_id": agent_id, "error_type": error_type})
@@ -158,7 +158,7 @@ class MetricsCollector:
     def record_custom_metric(self, metric_name: str, value: float, tags: Dict[str, str]):
         """Record a custom metric"""
         metric_entry = {
-            "timestamp": datetime.now(datetime.UTC).isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "value": value,
             "tags": tags
         }
@@ -188,7 +188,7 @@ class MetricsCollector:
         if metric_name not in self.custom_metrics:
             return
         
-        cutoff_time = datetime.now(datetime.UTC) - timedelta(minutes=rule.duration_minutes)
+        cutoff_time = datetime.now(timezone.utc) - timedelta(minutes=rule.duration_minutes)
         recent_values = []
         
         for entry in self.custom_metrics[metric_name]:
@@ -220,7 +220,7 @@ class MetricsCollector:
                 "current_value": avg_value,
                 "condition": rule.condition,
                 "duration_minutes": rule.duration_minutes,
-                "timestamp": datetime.now(datetime.UTC).isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
                 "message": f"{metric_name} {rule.condition} {rule.threshold} for {rule.duration_minutes} minutes"
             }
             
@@ -248,7 +248,7 @@ class MetricsCollector:
             agent_id for agent_id, metrics in self.agent_metrics.items()
             if metrics["last_activity"] and 
             datetime.fromisoformat(metrics["last_activity"]) > 
-            datetime.now(datetime.UTC) - timedelta(minutes=10)
+            datetime.now(timezone.utc) - timedelta(minutes=10)
         ])
         
         # Calculate totals
@@ -303,7 +303,7 @@ class MetricsCollector:
     
     def get_metrics_history(self, metric_name: str, hours: int = 1) -> List[Dict[str, Any]]:
         """Get historical data for a metric"""
-        cutoff_time = datetime.now(datetime.UTC) - timedelta(hours=hours)
+        cutoff_time = datetime.now(timezone.utc) - timedelta(hours=hours)
         
         if metric_name == "system":
             return [

--- a/src/bmasterai/integrations.py
+++ b/src/bmasterai/integrations.py
@@ -7,7 +7,7 @@ from email.mime.multipart import MIMEMultipart
 from typing import Dict, Any, List, Optional
 import sqlite3
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 import base64
 from abc import ABC, abstractmethod
 
@@ -234,8 +234,8 @@ class DatabaseConnector(BaseConnector):
                 VALUES (?, ?, ?, ?, ?, ?)
             ''', (
                 agent_id, name, status, 
-                datetime.now(datetime.UTC).isoformat(),
-                datetime.now(datetime.UTC).isoformat(),
+                datetime.now(timezone.utc).isoformat(),
+                datetime.now(timezone.utc).isoformat(),
                 json.dumps(metadata or {})
             ))
 
@@ -256,8 +256,8 @@ class DatabaseConnector(BaseConnector):
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             ''', (
                 task_id, agent_id, name, status, duration_ms,
-                datetime.now(datetime.UTC).isoformat(),
-                datetime.now(datetime.UTC).isoformat() if status == 'completed' else None,
+                datetime.now(timezone.utc).isoformat(),
+                datetime.now(timezone.utc).isoformat() if status == 'completed' else None,
                 json.dumps(metadata or {})
             ))
 
@@ -301,7 +301,7 @@ class WebhookConnector(BaseConnector):
 
     def test_connection(self) -> Dict[str, Any]:
         try:
-            test_payload = {'test': True, 'timestamp': datetime.now(datetime.UTC).isoformat()}
+            test_payload = {'test': True, 'timestamp': datetime.now(timezone.utc).isoformat()}
             response = requests.post(self.webhook_url, json=test_payload, headers=self.headers, timeout=10)
             return {'success': response.status_code < 400, 'status_code': response.status_code}
         except Exception as e:
@@ -351,7 +351,7 @@ class DiscordConnector(BaseConnector):
             'title': title,
             'description': description,
             'color': color,
-            'timestamp': datetime.now(datetime.UTC).isoformat(),
+            'timestamp': datetime.now(timezone.utc).isoformat(),
             'footer': {'text': 'BMasterAI'}
         }
 
@@ -392,7 +392,7 @@ class TeamsConnector(BaseConnector):
             'summary': title,
             'sections': [{
                 'activityTitle': title,
-                'activitySubtitle': datetime.now(datetime.UTC).strftime('%Y-%m-%d %H:%M:%S UTC'),
+                'activitySubtitle': datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC'),
                 'activityImage': 'https://cdn-icons-png.flaticon.com/512/4712/4712027.png',
                 'text': message,
                 'markdown': True

--- a/src/bmasterai/logging.py
+++ b/src/bmasterai/logging.py
@@ -3,7 +3,7 @@ import logging
 import json
 import time
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, Any, Optional, List
 from dataclasses import dataclass, asdict
 from enum import Enum
@@ -111,7 +111,7 @@ class BMasterLogger:
             metadata = {}
 
         entry = LogEntry(
-            timestamp=datetime.now(datetime.UTC).isoformat(),
+            timestamp=datetime.now(timezone.utc).isoformat(),
             event_id=str(uuid.uuid4()),
             agent_id=agent_id,
             event_type=event_type,

--- a/src/bmasterai/mcp_server.py
+++ b/src/bmasterai/mcp_server.py
@@ -13,7 +13,7 @@ Usage:
 """
 
 from typing import Dict, Any, List
-from datetime import datetime
+from datetime import datetime, timezone
 
 try:
     from fastmcp import FastMCP
@@ -103,7 +103,7 @@ Available tools:
         except Exception as e:
             return {
                 "error": f"Failed to get system status: {str(e)}",
-                "timestamp": datetime.now(datetime.UTC).isoformat()
+                "timestamp": datetime.now(timezone.utc).isoformat()
             }
 
     @mcp.tool()
@@ -178,7 +178,7 @@ Available tools:
         except Exception as e:
             return [{
                 "error": f"Failed to get alerts: {str(e)}",
-                "timestamp": datetime.now(datetime.UTC).isoformat()
+                "timestamp": datetime.now(timezone.utc).isoformat()
             }]
 
     @mcp.tool()


### PR DESCRIPTION
## Summary
- add Agno example that interacts with Gemini and records BMasterAI telemetry
- replace deprecated `datetime.UTC` references with `timezone.utc` across core modules and example utilities
- document the Agno telemetry example and its benefits
- allow optional Slack/Teams alerts via `bmasterai_telemetry` with token budgets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895fb4562d48328aeec31ae67182294